### PR TITLE
build error importing expensetypes and expensecategories modules

### DIFF
--- a/vue-expenses-client/src/store/index.js
+++ b/vue-expenses-client/src/store/index.js
@@ -1,25 +1,25 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
-import { alert } from '@/store/modules/alert';
-import { loader } from '@/store/modules/loader';
-import { account } from '@/store/modules/account';
-import { expenseTypes } from '@/store/modules/expenseTypes';
-import { expenseCategories } from '@/store/modules/expenseCategories';
-import { expenses } from '@/store/modules/expenses';
-import { statistics } from '@/store/modules/statistics';
+import Vue from "vue";
+import Vuex from "vuex";
+import { alert } from "@/store/modules/alert";
+import { loader } from "@/store/modules/loader";
+import { account } from "@/store/modules/account";
+import { expenseTypes } from "@/store/modules/expensetypes";
+import { expenseCategories } from "@/store/modules/expensecategories";
+import { expenses } from "@/store/modules/expenses";
+import { statistics } from "@/store/modules/statistics";
 
 Vue.use(Vuex);
 
 const store = new Vuex.Store({
-    modules: {
-        alert,
-        loader,
-        account,
-        expenseTypes,
-        expenseCategories,
-        expenses,
-        statistics
-    }
+  modules: {
+    alert,
+    loader,
+    account,
+    expenseTypes,
+    expenseCategories,
+    expenses,
+    statistics,
+  },
 });
 
 export default store;


### PR DESCRIPTION
It seems the import statements are case sensitive, fixed by making imports lowercase 